### PR TITLE
Adjust to use /v1 API (was not versioned previously).

### DIFF
--- a/arrakis_mcp_server.py
+++ b/arrakis_mcp_server.py
@@ -31,7 +31,7 @@ logger = logging.getLogger("arrakis-mcp")
 mcp = FastMCP("arrakis")
 
 # Default Arrakis server URL
-DEFAULT_ARRAKIS_URL = "http://localhost:7000"
+DEFAULT_ARRAKIS_URL = "http://localhost:7000/v1"
 # Will be set in main.
 sandbox_manager = None
 


### PR DESCRIPTION
Adjust to use the /v1 versioned API matching what is seen in the https://github.com/abshkbh/arrakis/commit/f3b6ba15aae9b7e96db223de48216b592642907f arrakis rest server update.